### PR TITLE
added API for managing web view modal navigation

### DIFF
--- a/Source/JS API/Navigation+Modal.swift
+++ b/Source/JS API/Navigation+Modal.swift
@@ -1,0 +1,29 @@
+//
+//  Navigation+Modal.swift
+//  THGHybridWeb
+//
+//  Created by Angelo Di Paolo on 6/15/15.
+//  Copyright (c) 2015 TheHolyGrail. All rights reserved.
+//
+
+import JavaScriptCore
+
+@objc protocol ModalNavigationJSExport: JSExport {
+    func presentModal()
+    func dismissModal()
+}
+
+extension Navigation: ModalNavigationJSExport {
+    
+    func presentModal() {
+        dispatch_async(dispatch_get_main_queue()) {
+            self.webViewController?.presentModalWebViewController()
+        }
+    }
+    
+    func dismissModal() {
+        dispatch_async(dispatch_get_main_queue()) {
+            self.parentViewController?.dismissViewControllerAnimated(true, completion: nil)
+        }
+    }
+}

--- a/Source/Web View/WebViewController.swift
+++ b/Source/Web View/WebViewController.swift
@@ -247,6 +247,17 @@ extension WebViewController {
     }
     
     /**
+     Call to present a navigation controller containing a new web view controller
+     as the root view controller. The existing web view instance is reused.
+    */
+    public func presentModalWebViewController() {
+        goBackInWebViewOnAppear = true
+        
+        let navigationController = UINavigationController(rootViewController: WebViewController(webView: webView, bridge: bridge))
+        presentViewController(navigationController, animated: true, completion: nil)
+    }
+    
+    /**
      Return `true` to have the web view controller push a new web view controller
      on the stack for a given navigation type of a request.
     */

--- a/THGHybridWeb.xcodeproj/project.pbxproj
+++ b/THGHybridWeb.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		1786AFD61B0E60AB005B7559 /* THGBridge.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1786AFD31B0E60AB005B7559 /* THGBridge.framework */; };
 		1786AFD71B0E60AB005B7559 /* THGFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1786AFD41B0E60AB005B7559 /* THGFoundation.framework */; };
 		1786AFD81B0E60AB005B7559 /* THGLog.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1786AFD51B0E60AB005B7559 /* THGLog.framework */; };
+		17BEBCA01B2F60B100B0FB3E /* Navigation+Modal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BEBC9F1B2F60B100B0FB3E /* Navigation+Modal.swift */; };
 		17E076E31B024AC4008F89EC /* UIWebView+JavaScriptContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E076E21B024AC4008F89EC /* UIWebView+JavaScriptContext.swift */; };
 		17E076EA1B025AA2008F89EC /* WebViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E076E91B025AA2008F89EC /* WebViewControllerTests.swift */; };
 /* End PBXBuildFile section */
@@ -79,6 +80,7 @@
 		1786AFD31B0E60AB005B7559 /* THGBridge.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = THGBridge.framework; path = Carthage/Build/iOS/THGBridge.framework; sourceTree = "<group>"; };
 		1786AFD41B0E60AB005B7559 /* THGFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = THGFoundation.framework; path = Carthage/Build/iOS/THGFoundation.framework; sourceTree = "<group>"; };
 		1786AFD51B0E60AB005B7559 /* THGLog.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = THGLog.framework; path = Carthage/Build/iOS/THGLog.framework; sourceTree = "<group>"; };
+		17BEBC9F1B2F60B100B0FB3E /* Navigation+Modal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Navigation+Modal.swift"; sourceTree = "<group>"; };
 		17E076E21B024AC4008F89EC /* UIWebView+JavaScriptContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIWebView+JavaScriptContext.swift"; sourceTree = "<group>"; };
 		17E076E91B025AA2008F89EC /* WebViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebViewControllerTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -183,6 +185,7 @@
 				177E5D8A1B00FE1A006BCBE2 /* HybridAPI.swift */,
 				177E5D8B1B00FE1A006BCBE2 /* JSValue+HybridAPI.swift */,
 				177E5D8C1B00FE1A006BCBE2 /* Navigation.swift */,
+				17BEBC9F1B2F60B100B0FB3E /* Navigation+Modal.swift */,
 				174CA6C41B20804400A80074 /* NavigationBar.swift */,
 				17711C0D1B20FDFB0043B71E /* BarButton.swift */,
 			);
@@ -316,6 +319,7 @@
 				177E5D931B00FE1A006BCBE2 /* HybridAPI+Share.swift in Sources */,
 				177E5D901B00FE1A006BCBE2 /* HybridAPI+Dialog.swift in Sources */,
 				177E5D951B00FE1A006BCBE2 /* JSValue+HybridAPI.swift in Sources */,
+				17BEBCA01B2F60B100B0FB3E /* Navigation+Modal.swift in Sources */,
 				17E076E31B024AC4008F89EC /* UIWebView+JavaScriptContext.swift in Sources */,
 				177E5D971B00FE1A006BCBE2 /* ViewControllerChild.swift in Sources */,
 			);

--- a/platformAPI.md
+++ b/platformAPI.md
@@ -115,6 +115,30 @@ Trigger a native pop navigation transition. By default it pops a view controller
 NativeBridge.navigation.animateBackward();
 
 ```
+
+#### presentModal()
+
+Trigger a native modal transition. By default the method presents a new web view controller with the current web view state. Does not affect web view history.
+
+**Example**
+
+```
+NativeBridge.navigation.presentModal();
+
+```
+
+#### dismissModal()
+
+Close the existing native modal view. Does not affect web view history.
+
+**Example**
+
+```
+NativeBridge.navigation.dismissModal();
+
+```
+
+
 ## NativeBridge.navigationBar Object ##
 
 #### setTitle()


### PR DESCRIPTION
I added the API below to the navigation object for displaying and closing modal web views. The API works similar to the `animateForward()` and `animateBackward()` methods in that it re-uses the shared web view when presenting the modal view controller and does not affect web browser history.
## Modal API
#### navigation.presentModal()

Trigger a native modal transition. By default the method presents a new web view controller with the current web view state. Does not affect web view history.

**Example**

```
NativeBridge.navigation.presentModal();

```
#### navigation.dismissModal()

Close the existing native modal view. Does not affect web view history.

**Example**

```
NativeBridge.navigation.dismissModal();

```
