### PR TITLE
remove navigation bar items when `null` or empty array is passed

### DIFF
--- a/Source/JS API/NavigationBar.swift
+++ b/Source/JS API/NavigationBar.swift
@@ -10,7 +10,7 @@ import JavaScriptCore
 
 @objc protocol NavigationBarJSExport: JSExport {
     func setTitle(title: String)
-    func setButtons(buttonsToSet: [[String: AnyObject]], _ callback: JSValue)
+    func setButtons(buttonsToSet: AnyObject?, _ callback: JSValue?)
 }
 
 @objc public class NavigationBar: ViewControllerChild {
@@ -18,12 +18,17 @@ import JavaScriptCore
     private var callback: JSValue?
     private var buttons: [Int: BarButton]? {
         didSet {
-            if let leftButton = buttons?[0]?.barButtonItem {
-                parentViewController?.navigationItem.leftBarButtonItem = leftButton
-            }
-            
-            if let rightButton = buttons?[1]?.barButtonItem {
-                parentViewController?.navigationItem.rightBarButtonItem = rightButton
+            if let buttons = buttons {
+                if let leftButton = buttons[0]?.barButtonItem {
+                    parentViewController?.navigationItem.leftBarButtonItem = leftButton
+                }
+                
+                if let rightButton = buttons[1]?.barButtonItem {
+                    parentViewController?.navigationItem.rightBarButtonItem = rightButton
+                }
+            } else {
+                parentViewController?.navigationItem.leftBarButtonItem = nil
+                parentViewController?.navigationItem.rightBarButtonItem = nil
             }
         }
     }
@@ -33,15 +38,22 @@ extension NavigationBar: NavigationBarJSExport {
     
     func setTitle(title: String) {
         dispatch_async(dispatch_get_main_queue()) {
-            parentViewController?.title = title
+            parentViewController?.navigationItem.title = title
         }
     }
     
-    func setButtons(buttonsToSet: [[String: AnyObject]], _ callback: JSValue) {
+    func setButtons(options: AnyObject?, _ callback: JSValue? = nil) {
         self.callback = callback
 
         dispatch_async(dispatch_get_main_queue()) {
-            self.buttons = BarButton.dictionaryFromJSONArray(buttonsToSet, callback: callback) // must set buttons on main thread
+            
+            if let buttonsToSet = options as? [[String: AnyObject]],
+                let callback = callback
+                where buttonsToSet.count > 0 {
+                    self.buttons = BarButton.dictionaryFromJSONArray(buttonsToSet, callback: callback) // must set buttons on main thread
+            } else {
+                self.buttons = nil
+            }
         }
     }
 }


### PR DESCRIPTION
fixes #9 
