### PR TITLE
track the web view's first completed loading cycle. Fixes #15

### DIFF
--- a/Source/Web View/WebViewController.swift
+++ b/Source/Web View/WebViewController.swift
@@ -100,6 +100,7 @@ public class WebViewController: UIViewController {
     private var showWebViewOnAppear = false
     private var storedScreenshotGUID: String? = nil
     private var goBackInWebViewOnAppear = false
+    private var firstLoadCycleCompleted = true
     private lazy var placeholderImageView: UIImageView = {
         return UIImageView(frame: self.view.bounds)
     }()
@@ -157,7 +158,7 @@ public class WebViewController: UIViewController {
         webView.frame = view.bounds
         view.addSubview(webView)
         
-        if !webView.loading {
+        if !webView.loading || firstLoadCycleCompleted {
             showWebViewOnAppear = true
         }
         
@@ -222,6 +223,7 @@ extension WebViewController {
     */
     final public func loadURL(url: NSURL) {
         self.url = url
+        firstLoadCycleCompleted = false
         let request = NSURLRequest(URL: url)
         webView.loadRequest(request)
     }
@@ -247,6 +249,7 @@ extension WebViewController: UIWebViewDelegate {
         }
 
         if !webView.loading {
+            firstLoadCycleCompleted = true
             updateBridgeContext() // todo: listen for context changes
             attemptToShowWebView()
         }


### PR DESCRIPTION
UIWebView’s `loading` is not a reliable source for detecting when a web
view has finished loading. It will continue to report `true` even when
the page appears to have finished loading. The best workaround I found
was to track the first time `loading` reports false in
webViewDidFinishLoad and consider that an estimation of a safe time to
unhide the web view.

This resolves issue #15, a bug that was causing the web view to remain
in a hidden state after making `presentModal()` and `animateForward()`
bridge calls.
