### PR TITLE
add create JS context event and track appearance/disappearance states

### DIFF
--- a/Source/Web View/WebViewController.swift
+++ b/Source/Web View/WebViewController.swift
@@ -161,9 +161,6 @@ public class WebViewController: UIViewController {
         
         edgesForExtendedLayout = .None
         view.addSubview(placeholderImageView)
-        
-        let button = UIBarButtonItem(title: "Reload", style: UIBarButtonItemStyle.Done, target: self, action: "reloadFoo")
-        navigationItem.rightBarButtonItem = button
     }
     
     func reloadFoo() {


### PR DESCRIPTION
- Fixes #39 - an issue that resulted in a "frozen" screen after pop/dismissing from animateForward()/presentModal() calls 
- Enables bridge objects to be added to JS context at the moment of creation so that bridge objects are available when the page JS executes. Allows web developers to avoid waiting to call `view.show()` when loading a page.
