### PR TITLE
add `newState()` method that allows web to explicitly create a new bridge API object

### DIFF
--- a/Source/JS API/HybridAPI+View.swift
+++ b/Source/JS API/HybridAPI+View.swift
@@ -18,7 +18,6 @@ import UIKit
 @objc public class ViewAPI: ViewControllerChild  {
 
     private var hasAppeared = false
-    
     internal var onAppearCallback: JSValue? {
         didSet {
             if hasAppeared {
@@ -26,12 +25,7 @@ import UIKit
             }
         }
     }
-    
     private var onDisappearCallback: JSValue?
-    
-    weak var webViewController: WebViewController? {
-        return parentViewController as? WebViewController
-    }
     
     func appeared() {
         hasAppeared = true

--- a/Source/JS API/HybridAPI.swift
+++ b/Source/JS API/HybridAPI.swift
@@ -19,6 +19,7 @@ import THGBridge
     var view: ViewAPI {get}
     var tabBar: TabBar {get}
     func info() -> [String: String]
+    func newState()
 }
 
 /**
@@ -53,5 +54,10 @@ import THGBridge
     
     public func info() -> [String: String] {
         return HybridAPIInfo(appVersion: "1.0").asDictionary
+    }
+    
+    func newState() {
+        webViewController?.hybridAPI = nil
+        webViewController?.addBridgeAPIObject()
     }
 }

--- a/Source/Web View/ViewControllerChild.swift
+++ b/Source/Web View/ViewControllerChild.swift
@@ -25,3 +25,12 @@ protocol ViewControllerChildType {
         self.parentViewController = parentViewController
     }
 }
+
+// MARK: WebViewController Integration
+
+extension ViewControllerChild {
+    
+    weak var webViewController: WebViewController? {
+        return parentViewController as? WebViewController
+    }
+}

--- a/platformAPI.md
+++ b/platformAPI.md
@@ -33,6 +33,18 @@ if (window.NativeBridge === undefined) {
 
 ## NativeBridge Object ##
 
+
+#### newState()
+
+Creates a new `NativeBridge` object and adds it to the existing view and JavaScript context.
+
+**Example**
+
+```
+NativeBridge.newState();
+
+```
+
 #### info()
 
 Provides information that identifies the device and platform.


### PR DESCRIPTION
`newState()` creates a new `NativeBridge` object and adds it to the existing view and JavaScript context.

**Example:**

```
NativeBridge.newState();
```
