### PR TITLE
ignore query string when matching external URLs against the `returnURL`

### DIFF
--- a/Source/Web View/WebViewController.swift
+++ b/Source/Web View/WebViewController.swift
@@ -482,8 +482,8 @@ extension WebViewController {
     }
     
     final func shouldInterceptExternalURL(url: NSURL) -> Bool {
-        if let requestedURLString = url.absoluteString,
-            let returnURLString = externalReturnURL?.absoluteString
+        if let requestedURLString = url.absoluteStringWithoutQuery,
+            let returnURLString = externalReturnURL?.absoluteStringWithoutQuery
             where requestedURLString.rangeOfString(returnURLString) != nil {
                 return true
         }
@@ -736,5 +736,14 @@ extension UIWebView {
     func didCreateJavaScriptContext(context: JSContext) {
         hackContext = context
         (delegate as? WebViewController)?.didCreateJavaScriptContext(context)
+    }
+}
+
+extension NSURL {
+    /// Get the absolute URL string value without the query string.
+    var absoluteStringWithoutQuery: String? {
+        let components = NSURLComponents(URL: self, resolvingAgainstBaseURL: false)
+        components?.query = nil
+        return components?.string
     }
 }

--- a/platformAPI.md
+++ b/platformAPI.md
@@ -289,12 +289,19 @@ The external web view modal contains "Back" left navigation bar button and a "Do
 
 The Done button dismisses the external web view regardless of the web history.
 
+**Usage**
+
+The `presentExternalURL()` method can be used when the hybrid web application needs to navigate to an external web application or website that the hybrid web app developer does not control. It allows the user to freely navigate forward and backward in a new web view instance without modfiying the web history of the hybrid web application.
+
+An optional `returnURL` option can be set that enables the hybrid web application to intercept a request of the external web view in order to return to the original hybrid web application's web view. When the external web view attempts to load a request the request's URL will be compared against the `returnURL` value to determine if the request should be intercepted. Ignoring the query string value, the `returnURL` will match against any subset of the intercepted URL including the scheme, domain, port, and path. For example the `returnURL` value of `"https//github.com/TheHolyGrail"` will intercept the URLs `"https//github.com/TheHolyGrail/Zoot"` and `"https//github.com/TheHolyGrail/BridgeOfDeath"` but not the URL `"https//github.com/"`.
+
+After a request has been matched against the `returnURL` value the bridge prevents the request from loading inside the external web view and instead loads it into the original hybrid web application's web view. The external web view is dismissed and the user returns to the original web application's web view with the intercepted request loaded into it.
 
 **Parameters**
 
 - (object) - Options object.
   - `url` (string) - External URL to load into the new modal web view.
-  - `returnURL` (string) - A subset of the URL that should be intercepted and loaded into the original web view. The external web view modal will be dismissed and the URL will not be loaded in the external web view. Ignoring the query string value, the `returnURL` will match against any subset of the intercepted URL including the scheme, domain, port, and path. For example the `returnURL` value of `"https//github.com/TheHolyGrail"` will intercept the URLs `"https//github.com/TheHolyGrail/Zoot"` and `"https//github.com/TheHolyGrail/BridgeOfDeath"` but not the URL `"https//github.com/"`.
+  - `returnURL` (string) - A subset of the URL to be intercepted in order to return to the presenting web view.
   - `title` (string) - Title text for the navigation bar of the external web view.
 
 **Example**

--- a/platformAPI.md
+++ b/platformAPI.md
@@ -294,7 +294,7 @@ The Done button dismisses the external web view regardless of the web history.
 
 - (object) - Options object.
   - `url` (string) - External URL to load into the new modal web view.
-  - `returnURL` (string) - A subset of the URL that should be intercepted and loaded into the original web view. The external web view modal will be dismissed and the URL will not be loaded in the external web view. Ignoring the query string value, the returnURL will match against any subset of the intercepted URL inlucding the scheme, domain, port, and path. For example the `returnURL` value of `"https//github.com/TheHolyGrail"` will intercept the URLs `"https//github.com/TheHolyGrail/Zoot"` and `"https//github.com/TheHolyGrail/BridgeOfDeath"` but not the URL `"https//github.com/"`.
+  - `returnURL` (string) - A subset of the URL that should be intercepted and loaded into the original web view. The external web view modal will be dismissed and the URL will not be loaded in the external web view. Ignoring the query string value, the `returnURL` will match against any subset of the intercepted URL including the scheme, domain, port, and path. For example the `returnURL` value of `"https//github.com/TheHolyGrail"` will intercept the URLs `"https//github.com/TheHolyGrail/Zoot"` and `"https//github.com/TheHolyGrail/BridgeOfDeath"` but not the URL `"https//github.com/"`.
   - `title` (string) - Title text for the navigation bar of the external web view.
 
 **Example**

--- a/platformAPI.md
+++ b/platformAPI.md
@@ -294,18 +294,17 @@ The Done button dismisses the external web view regardless of the web history.
 
 - (object) - Options object.
   - `url` (string) - External URL to load into the new modal web view.
-  - `returnURL` (string) - URL that the external web view should intercept and load into the original web view that had presented the external web view. The external web view modal will be dismissed and the URL will not be loaded in the external web view. The the intercepted URL can match any part of the return URL. For example the returnURL value of `"www.walmart.com"` will intercept any URL that contains the host `www.walmart.com`.
+  - `returnURL` (string) - A subset of the URL that should be intercepted and loaded into the original web view. The external web view modal will be dismissed and the URL will not be loaded in the external web view. Ignoring the query string value, the returnURL will match against any subset of the intercepted URL inlucding the scheme, domain, port, and path. For example the `returnURL` value of `"https//github.com/TheHolyGrail"` will intercept the URLs `"https//github.com/TheHolyGrail/Zoot"` and `"https//github.com/TheHolyGrail/BridgeOfDeath"` but not the URL `"https//github.com/"`.
   - `title` (string) - Title text for the navigation bar of the external web view.
 
 **Example**
 
 ```
 var options = {
-  url: "http://www.apple.com/", 
-  returnURL: "www.walmart.com"
+  url: "http://www.walmart.com/", 
+  returnURL: "https//github.com/TheHolyGrail"
 };
 NativeBridge.navigation.presentExternalURL(options);
-
 ```
 
 #### dismissExternalURL()


### PR DESCRIPTION
Fixes #56
