### PR TITLE
add `onWillAppear` callback to view API to enable the view to be shown before it is on screen

### DIFF
--- a/Source/JS API/HybridAPI+View.swift
+++ b/Source/JS API/HybridAPI+View.swift
@@ -19,6 +19,11 @@ import UIKit
 
     internal var onAppearCallback: JSValue?
     private var onDisappearCallback: JSValue?
+    internal var willAppearCallback: JSValue?
+
+    public func willAppear() {
+        willAppearCallback?.safelyCallWithArguments(nil)
+    }
     
     public func appeared() {
         onAppearCallback?.safelyCallWithArguments(nil)

--- a/Source/Web View/WebViewController.swift
+++ b/Source/Web View/WebViewController.swift
@@ -215,6 +215,8 @@ public class WebViewController: UIViewController {
             
             view.removeDoubleTapGestures()
             
+            hybridAPI?.view.willAppear()
+            
         case .Unknown: break
         }
     }
@@ -523,8 +525,9 @@ extension WebViewController {
         webViewController.addBridgeAPIObject()
         webViewController.hybridAPI?.navigationBar.title = options?.title
         webViewController.hidesBottomBarWhenPushed = options?.tabBarHidden ?? false
-        webViewController.hybridAPI?.view.onAppearCallback = options?.onAppearCallback?.asValidValue
-        
+        webViewController.hybridAPI?.view.onAppearCallback = options?.onAppearCallback
+        webViewController.hybridAPI?.view.willAppearCallback = options?.willAppearCallback
+
         if let navigationBarButtons = options?.navigationBarButtons {
             webViewController.hybridAPI?.navigationBar.configureButtons(options?.navigationBarButtons, callback: options?.navigationBarButtonCallback)
         }

--- a/Source/Web View/WebViewControllerOptions.swift
+++ b/Source/Web View/WebViewControllerOptions.swift
@@ -12,6 +12,7 @@ public struct WebViewControllerOptions {
     private (set) public var title: String?
     private (set) public var tabBarHidden = false
     private (set) public var onAppearCallback: JSValue?
+    private (set) public var willAppearCallback: JSValue?
     private (set) public var navigationBarButtonCallback: JSValue?
     private (set) public var navigationBarButtons: JSValue?
 
@@ -20,7 +21,8 @@ public struct WebViewControllerOptions {
         if let optionsValue = javaScriptValue.asValidValue {
             self.title = javaScriptValue.valueForProperty("title").asString
             self.tabBarHidden = javaScriptValue.valueForProperty("tabBarHidden").toBool() ?? false
-            self.onAppearCallback = javaScriptValue.valueForProperty("onAppear")
+            self.onAppearCallback = javaScriptValue.valueForProperty("onAppear").asValidValue
+            self.willAppearCallback = javaScriptValue.valueForProperty("onWillAppear").asValidValue
             self.navigationBarButtonCallback = javaScriptValue.valueForProperty("onNavigationBarButtonTap").asValidValue
             self.navigationBarButtons = javaScriptValue.valueForProperty("navigationBarButtons").asValidValue
         }

--- a/platformAPI.md
+++ b/platformAPI.md
@@ -176,24 +176,25 @@ By default when the user taps the back button the web view will go back in web h
 - (object) - Optional options object.
   - `tabBarHidden` (boolean) - Determines whether the page we're animating to, shows or hides the tab bar in iOS. If this option is not provided, the default behavior in iOS would be to show the tab bar. This option is not applicable to Android, and will be ignored.
   - `title` (string) - Header title text to show on the view that is being animated to.
+  - `onWillAppear` (function) - Callback that will be run before the view appears on screen as a result of the animation. The callback runs before `onAppear`.
 
 **Example**
 
-Trigger a simple animate forward transition.
+Perform a simple animate forward transition.
 
 ```
 NativeBridge.navigation.animateForward();
 
 ```
 
-Trigger an animate forward transition that hides the tab bar.
+Perform a forward animation transition and hide the tab bar.
 
 ```
 NativeBridge.navigation.animateForward({tabBarHidden: true});
 
 ```
 
-Trigger an animate forward transition sets the title of the new view.
+Perform a forward animation transition and set the title of the new view.
 
 ```
 // indicate to the native bridge to animate forward to a new view
@@ -204,6 +205,18 @@ NativeBridge.navigation.animateForward({
 
 // load new page state
 window.location.href = "/pageTwo"
+```
+
+Perform a forward animation transition with an `onWillAppear` callback.
+
+```
+NativeBridge.navigation.animateForward({
+  title: "Page Two",
+  tabBarHidden: false,
+  onWillAppear: function () {
+    NativeBridge.view.show();
+  }
+});
 ```
 
 ### animateBackward()


### PR DESCRIPTION
The callback can be passed as an option to `animateForward()`:

```
NativeBridge.navigation.animateForward({
  title: "Page Two",
  onWillAppear: function () {
    NativeBridge.view.show();
  }
});
```
