### PR TITLE
keep reference to dialog API's alert view so the delegate can be set to nil

### DIFF
--- a/Source/JS API/DialogAlert.swift
+++ b/Source/JS API/DialogAlert.swift
@@ -12,18 +12,24 @@ import UIKit
 @objc class DialogAlert: NSObject {
     var callback: ((Int) -> Void)?
     private (set) var dialogOptions: DialogOptions
+    private var alertView: UIAlertView?
     
     init(dialogOptions: DialogOptions) {
         self.dialogOptions = dialogOptions
     }
     
+    deinit {
+        alertView?.delegate = nil
+    }
+    
     func show(callback: (Int) -> Void) {
         self.callback = callback
         
-        alertView.show()
+        alertView = createAlertView()
+        alertView?.show()
     }
     
-    var alertView: UIAlertView {
+    func createAlertView() -> UIAlertView {
         let alert = UIAlertView(title: dialogOptions.title, message: dialogOptions.message, delegate: self, cancelButtonTitle: nil)
         
         for action in dialogOptions.actions {


### PR DESCRIPTION
This fixes an issue where the UIAlertView's delegate can be released before a user taps a button. this attempts to resolve an EXC_BAD_ACCESS crash on iOS 7 that originates from `UIAlertView`
