### PR TITLE
remove argument labels from share and dialog APIs to fix tests

### DIFF
--- a/Source/JS API/HybridAPI+Dialog.swift
+++ b/Source/JS API/HybridAPI+Dialog.swift
@@ -9,12 +9,11 @@
 import JavaScriptCore
 
 @objc protocol DialogJSExport: JSExport {
-    func dialog(options: [String: AnyObject], _ callback: JSValue)
+    func dialog(_ options: [String: AnyObject], _ callback: JSValue)
 }
 
 extension HybridAPI {
-    
-    func dialog(options: [String: AnyObject], _ callback: JSValue) {
+    func dialog(_ options: [String: AnyObject], _ callback: JSValue) {
         log(.Debug, "options:\(options), callback\(callback)") // provide breadcrumbs
         dialog.show(options: options, callback: callback)
     }

--- a/Source/JS API/HybridAPI+Share.swift
+++ b/Source/JS API/HybridAPI+Share.swift
@@ -9,12 +9,11 @@
 import JavaScriptCore
 
 @objc protocol ShareJSExport: JSExport {
-    func share(options: [String: Any])
+    func share(_ options: [String: AnyObject])
 }
 
 extension HybridAPI {
-    
-    func share(options: [String: Any]) {
+    func share(_ options: [String: AnyObject]) {
         DispatchQueue.main.async {
             if let activityViewController = HybridAPI.activityViewController(withOptions: options) {
                 self.parentViewController?.present(activityViewController, animated: true, completion: nil)

--- a/Source/Web View/WebViewController.swift
+++ b/Source/Web View/WebViewController.swift
@@ -446,7 +446,7 @@ open class WebViewController: UIViewController {
     
     final func shouldInterceptExternalURL(url: URL) -> Bool {
         if let requestedURLString = url.absoluteStringWithoutQuery,
-            let returnURLString = externalReturnURL?.absoluteStringWithoutQuery, (requestedURLString as NSString).range(of: returnURLString) != nil {
+            let returnURLString = externalReturnURL?.absoluteStringWithoutQuery, (requestedURLString as NSString).range(of: returnURLString).location != NSNotFound {
             return true
         }
         


### PR DESCRIPTION
- Fixes to get unit tests passing that [started failing](https://travis-ci.org/Electrode-iOS/ELHybridWeb/builds/181562428) after migrating to Swift 3
- Fix Xcode warnings