### PR TITLE
update JSContext creation event for Swift 3

### DIFF
--- a/Example/ZootExample.xcodeproj/project.pbxproj
+++ b/Example/ZootExample.xcodeproj/project.pbxproj
@@ -7,17 +7,17 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		177DA81F1B064C450006457E /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 177DA81D1B064C450006457E /* DetailViewController.swift */; };
-		177DA8201B064C450006457E /* DetailViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 177DA81E1B064C450006457E /* DetailViewController.xib */; };
-		177E5DB91B00FF22006BCBE2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 177E5DB81B00FF22006BCBE2 /* AppDelegate.swift */; };
-		177E5DBB1B00FF22006BCBE2 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 177E5DBA1B00FF22006BCBE2 /* ViewController.swift */; };
-		177E5DC01B00FF22006BCBE2 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 177E5DBF1B00FF22006BCBE2 /* Images.xcassets */; };
-		177E5DC31B00FF22006BCBE2 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 177E5DC11B00FF22006BCBE2 /* LaunchScreen.xib */; };
 		177E5DCF1B00FF22006BCBE2 /* ELHybridWebExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 177E5DCE1B00FF22006BCBE2 /* ELHybridWebExampleTests.swift */; };
 		1786AFE11B0E611F005B7559 /* ELHybridWeb.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 17E55D681B0E419900DA11BB /* ELHybridWeb.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		17E55D6B1B0E41A900DA11BB /* ELHybridWeb.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 17E55D681B0E419900DA11BB /* ELHybridWeb.framework */; };
-		17EA19721B0ABB5300E011CB /* ViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 17EA19711B0ABB5300E011CB /* ViewController.xib */; };
-		17ED5C971B0B558E00E1AE34 /* HybridAPI+NativeDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17ED5C961B0B558E00E1AE34 /* HybridAPI+NativeDetailView.swift */; };
+		196843481E27F47400EC8BAC /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 196843471E27F47400EC8BAC /* Info.plist */; };
+		196843501E27F48A00EC8BAC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 196843491E27F48A00EC8BAC /* AppDelegate.swift */; };
+		196843511E27F48A00EC8BAC /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1968434A1E27F48A00EC8BAC /* DetailViewController.swift */; };
+		196843521E27F48A00EC8BAC /* DetailViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1968434B1E27F48A00EC8BAC /* DetailViewController.xib */; };
+		196843531E27F48A00EC8BAC /* HybridAPI+NativeDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1968434C1E27F48A00EC8BAC /* HybridAPI+NativeDetailView.swift */; };
+		196843541E27F48A00EC8BAC /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1968434D1E27F48A00EC8BAC /* Images.xcassets */; };
+		196843551E27F48A00EC8BAC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1968434E1E27F48A00EC8BAC /* ViewController.swift */; };
+		196843561E27F48A00EC8BAC /* ViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1968434F1E27F48A00EC8BAC /* ViewController.xib */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -66,20 +66,19 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		177DA81D1B064C450006457E /* DetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
-		177DA81E1B064C450006457E /* DetailViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = DetailViewController.xib; sourceTree = "<group>"; };
 		177E5DB31B00FF22006BCBE2 /* ELHybridWebExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ELHybridWebExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		177E5DB71B00FF22006BCBE2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		177E5DB81B00FF22006BCBE2 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		177E5DBA1B00FF22006BCBE2 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
-		177E5DBF1B00FF22006BCBE2 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
-		177E5DC21B00FF22006BCBE2 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
 		177E5DC81B00FF22006BCBE2 /* ELHybridWebExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ELHybridWebExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		177E5DCD1B00FF22006BCBE2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		177E5DCE1B00FF22006BCBE2 /* ELHybridWebExampleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ELHybridWebExampleTests.swift; sourceTree = "<group>"; };
 		17E55D621B0E419900DA11BB /* ELHybridWeb.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ELHybridWeb.xcodeproj; path = ../ELHybridWeb.xcodeproj; sourceTree = "<group>"; };
-		17EA19711B0ABB5300E011CB /* ViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ViewController.xib; sourceTree = "<group>"; };
-		17ED5C961B0B558E00E1AE34 /* HybridAPI+NativeDetailView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "HybridAPI+NativeDetailView.swift"; sourceTree = "<group>"; };
+		196843471E27F47400EC8BAC /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = ZootExample/Info.plist; sourceTree = SOURCE_ROOT; };
+		196843491E27F48A00EC8BAC /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = ZootExample/AppDelegate.swift; sourceTree = SOURCE_ROOT; };
+		1968434A1E27F48A00EC8BAC /* DetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DetailViewController.swift; path = ZootExample/DetailViewController.swift; sourceTree = SOURCE_ROOT; };
+		1968434B1E27F48A00EC8BAC /* DetailViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = DetailViewController.xib; path = ZootExample/DetailViewController.xib; sourceTree = SOURCE_ROOT; };
+		1968434C1E27F48A00EC8BAC /* HybridAPI+NativeDetailView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "HybridAPI+NativeDetailView.swift"; path = "ZootExample/HybridAPI+NativeDetailView.swift"; sourceTree = SOURCE_ROOT; };
+		1968434D1E27F48A00EC8BAC /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = ZootExample/Images.xcassets; sourceTree = SOURCE_ROOT; };
+		1968434E1E27F48A00EC8BAC /* ViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ViewController.swift; path = ZootExample/ViewController.swift; sourceTree = SOURCE_ROOT; };
+		1968434F1E27F48A00EC8BAC /* ViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = ViewController.xib; path = ZootExample/ViewController.xib; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -123,14 +122,13 @@
 		177E5DB51B00FF22006BCBE2 /* ELHybridWebExample */ = {
 			isa = PBXGroup;
 			children = (
-				177E5DB81B00FF22006BCBE2 /* AppDelegate.swift */,
-				177E5DBA1B00FF22006BCBE2 /* ViewController.swift */,
-				17EA19711B0ABB5300E011CB /* ViewController.xib */,
-				177DA81D1B064C450006457E /* DetailViewController.swift */,
-				177DA81E1B064C450006457E /* DetailViewController.xib */,
-				17ED5C961B0B558E00E1AE34 /* HybridAPI+NativeDetailView.swift */,
-				177E5DBF1B00FF22006BCBE2 /* Images.xcassets */,
-				177E5DC11B00FF22006BCBE2 /* LaunchScreen.xib */,
+				196843491E27F48A00EC8BAC /* AppDelegate.swift */,
+				1968434A1E27F48A00EC8BAC /* DetailViewController.swift */,
+				1968434B1E27F48A00EC8BAC /* DetailViewController.xib */,
+				1968434C1E27F48A00EC8BAC /* HybridAPI+NativeDetailView.swift */,
+				1968434D1E27F48A00EC8BAC /* Images.xcassets */,
+				1968434E1E27F48A00EC8BAC /* ViewController.swift */,
+				1968434F1E27F48A00EC8BAC /* ViewController.xib */,
 				177E5DB61B00FF22006BCBE2 /* Supporting Files */,
 			);
 			path = ELHybridWebExample;
@@ -139,7 +137,7 @@
 		177E5DB61B00FF22006BCBE2 /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
-				177E5DB71B00FF22006BCBE2 /* Info.plist */,
+				196843471E27F47400EC8BAC /* Info.plist */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -222,6 +220,7 @@
 				TargetAttributes = {
 					177E5DB21B00FF22006BCBE2 = {
 						CreatedOnToolsVersion = 6.3.1;
+						LastSwiftMigration = 0820;
 					};
 					177E5DC71B00FF22006BCBE2 = {
 						CreatedOnToolsVersion = 6.3.1;
@@ -229,7 +228,7 @@
 					};
 				};
 			};
-			buildConfigurationList = 177E5DAE1B00FF22006BCBE2 /* Build configuration list for PBXProject "ELHybridWebExample" */;
+			buildConfigurationList = 177E5DAE1B00FF22006BCBE2 /* Build configuration list for PBXProject "ZootExample" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
@@ -276,10 +275,10 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				177E5DC31B00FF22006BCBE2 /* LaunchScreen.xib in Resources */,
-				177DA8201B064C450006457E /* DetailViewController.xib in Resources */,
-				17EA19721B0ABB5300E011CB /* ViewController.xib in Resources */,
-				177E5DC01B00FF22006BCBE2 /* Images.xcassets in Resources */,
+				196843561E27F48A00EC8BAC /* ViewController.xib in Resources */,
+				196843481E27F47400EC8BAC /* Info.plist in Resources */,
+				196843541E27F48A00EC8BAC /* Images.xcassets in Resources */,
+				196843521E27F48A00EC8BAC /* DetailViewController.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -297,10 +296,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				177DA81F1B064C450006457E /* DetailViewController.swift in Sources */,
-				177E5DBB1B00FF22006BCBE2 /* ViewController.swift in Sources */,
-				17ED5C971B0B558E00E1AE34 /* HybridAPI+NativeDetailView.swift in Sources */,
-				177E5DB91B00FF22006BCBE2 /* AppDelegate.swift in Sources */,
+				196843501E27F48A00EC8BAC /* AppDelegate.swift in Sources */,
+				196843531E27F48A00EC8BAC /* HybridAPI+NativeDetailView.swift in Sources */,
+				196843551E27F48A00EC8BAC /* ViewController.swift in Sources */,
+				196843511E27F48A00EC8BAC /* DetailViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -326,17 +325,6 @@
 			targetProxy = 1786AFE21B0E611F005B7559 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
-
-/* Begin PBXVariantGroup section */
-		177E5DC11B00FF22006BCBE2 /* LaunchScreen.xib */ = {
-			isa = PBXVariantGroup;
-			children = (
-				177E5DC21B00FF22006BCBE2 /* Base */,
-			);
-			name = LaunchScreen.xib;
-			sourceTree = "<group>";
-		};
-/* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
 		177E5DD01B00FF22006BCBE2 /* Debug */ = {
@@ -380,6 +368,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -417,6 +406,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};
@@ -426,10 +416,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
-				INFOPLIST_FILE = ELHybridWebExample/Info.plist;
+				INFOPLIST_FILE = ZootExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -437,16 +430,19 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
-				INFOPLIST_FILE = ELHybridWebExample/Info.plist;
+				INFOPLIST_FILE = ZootExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
 		177E5DD61B00FF22006BCBE2 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
@@ -466,6 +462,7 @@
 		177E5DD71B00FF22006BCBE2 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
@@ -481,7 +478,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		177E5DAE1B00FF22006BCBE2 /* Build configuration list for PBXProject "ELHybridWebExample" */ = {
+		177E5DAE1B00FF22006BCBE2 /* Build configuration list for PBXProject "ZootExample" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				177E5DD01B00FF22006BCBE2 /* Debug */,

--- a/Example/ZootExample/AppDelegate.swift
+++ b/Example/ZootExample/AppDelegate.swift
@@ -18,7 +18,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let viewController = ViewController(nibName: "ViewController", bundle: nil)
         let navController = UINavigationController(rootViewController: viewController)
 
-        window = UIWindow(frame: UIScreen.mainScreen().bounds)
+        window = UIWindow(frame: UIScreen.main.bounds)
         window?.rootViewController = navController
         window?.makeKeyAndVisible()
         

--- a/Example/ZootExample/AppDelegate.swift
+++ b/Example/ZootExample/AppDelegate.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import ELHybridWeb
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -14,10 +15,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
-        let viewController = ViewController(nibName: "ViewController", bundle: nil)
-        let navController = UINavigationController(rootViewController: viewController)
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]? = nil) -> Bool {
+//        let viewController = ViewController(nibName: "ViewController", bundle: nil)
+        let webViewController = WebViewController()
+        let url = URL(string: "http://bridgeofdeath.herokuapp.com/")!
+        webViewController.load(url: url)
 
+        let navController = UINavigationController(rootViewController: webViewController)
+
+        
+        
         window = UIWindow(frame: UIScreen.main.bounds)
         window?.rootViewController = navController
         window?.makeKeyAndVisible()

--- a/Example/ZootExample/DetailViewController.swift
+++ b/Example/ZootExample/DetailViewController.swift
@@ -31,7 +31,7 @@ class DetailViewController: UIViewController {
             detailLabel.text = "Detail ID: \(detailID)"
         }
         
-        webViewButton.enabled = (previousWebViewController != nil)
+        webViewButton.isEnabled = (previousWebViewController != nil)
     }
     
     /**
@@ -39,7 +39,7 @@ class DetailViewController: UIViewController {
     */
     @IBAction func pushWebViewCallback(sender: UIButton) {
         
-        webCallback?.callWithArguments([testOutput])
+        webCallback?.call(withArguments: [testOutput])
         previousWebViewController?.pushWebViewController()
     }
 }

--- a/Example/ZootExample/Info.plist
+++ b/Example/ZootExample/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsArbitraryLoads</key>
+        <true/>
+    </dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>

--- a/Example/ZootExample/Info.plist
+++ b/Example/ZootExample/Info.plist
@@ -22,8 +22,8 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>UILaunchStoryboardName</key>
-	<string>LaunchScreen</string>
+	<key>LSApplicationCategoryType</key>
+	<string></string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>

--- a/Example/ZootExample/ViewController.swift
+++ b/Example/ZootExample/ViewController.swift
@@ -19,7 +19,7 @@ class ViewController: UIViewController {
     @IBAction func pushWebView(sender: UIButton) {
         if let url = webViewURL {
             let webController = WebViewController()
-            webController.loadURL(url)
+            webController.load(url: url as URL)
             navigationController?.pushViewController(webController, animated: true)
         }
     }

--- a/Source/Web View/WebViewController.swift
+++ b/Source/Web View/WebViewController.swift
@@ -771,7 +771,7 @@ public extension NSObject {
         }
     }
     
-    func webView(webView: AnyObject, didCreateJavaScriptContext context: JSContext, forFrame frame: AnyObject) {
+    func webView(_ webView: AnyObject, didCreateJavaScriptContext context: JSContext, forFrame frame: AnyObject) {
         let notifyWebviews = { () -> Void in
             let allWebViews = globalWebViews.allObjects
             for webView in allWebViews {


### PR DESCRIPTION
- Update example project to work with Swift 3
- Update JSContext creation event (`webView(_:didCreateJavaScriptContext:forFrame:)` to work with Swift 3 changes 
