### PR TITLE
update several APIs to export to JS properly after Swift 3 migration changes 

### DIFF
--- a/ELHybridWebTests/NavigationBarTests.swift
+++ b/ELHybridWebTests/NavigationBarTests.swift
@@ -146,4 +146,23 @@ class NavigationBarTests: XCTestCase {
 //        
 //        waitForExpectationsWithTimeout(2.0, handler: nil)
 //    }
+
+    func testSetTitleExport() {
+        let webController = WebViewController()
+        webController.addBridgeAPIObject()
+        
+        let result = webController.bridgeContext.evaluateScript("NativeBridge.navigationBar.setTitle")!
+        XCTAssert(result.isObject)
+        XCTAssert(result.toObject() is NSDictionary)
+    }
+    
+    func testSetButtonsExport() {
+        let webController = WebViewController()
+        webController.addBridgeAPIObject()
+        
+        let result = webController.bridgeContext.evaluateScript("NativeBridge.navigationBar.setButtons")!
+        XCTAssert(result.isObject)
+        XCTAssert(result.toObject() is NSDictionary)
+    }
+    
 }

--- a/ELHybridWebTests/NavigationExternalTests.swift
+++ b/ELHybridWebTests/NavigationExternalTests.swift
@@ -32,12 +32,28 @@ class NavigationExternalTests: XCTestCase {
     func testFailedInitialization() {
         let options = ExternalNavigationOptions(options: ["UrL" : "foo"])
         XCTAssertTrue(options == nil)
-
+    }
+    
+    func testPresentExternalURLExport() {
+        let webController = WebViewController()
+        webController.addBridgeAPIObject()
+        
+        let result = webController.bridgeContext.evaluateScript("NativeBridge.navigation.presentExternalURL")!
+        XCTAssert(result.isObject)
+        XCTAssert(result.toObject() is NSDictionary)
+    }
+    
+    func testDismissExternalURLExport() {
+        let webController = WebViewController()
+        webController.addBridgeAPIObject()
+        
+        let result = webController.bridgeContext.evaluateScript("NativeBridge.navigation.dismissExternalURL")!
+        XCTAssert(result.isObject)
+        XCTAssert(result.toObject() is NSDictionary)
     }
 }
 
 extension ExternalNavigationOptions {
-    
     static func testOptions() -> ExternalNavigationOptions? {
         return ExternalNavigationOptions(options: NavigationExternalTests.optionJSON)
     }

--- a/ELHybridWebTests/ViewAPITests.swift
+++ b/ELHybridWebTests/ViewAPITests.swift
@@ -12,7 +12,6 @@ import XCTest
 import JavaScriptCore
 
 class ViewAPITests: XCTestCase {
-    
     func testParentViewControllerChange() {
         let webController = WebViewController()
         let api = HybridAPI(parentViewController: webController)
@@ -49,6 +48,23 @@ class ViewAPITests: XCTestCase {
         waitForExpectations(timeout: 3.0) { error in
             XCTAssertFalse(webController.webView.isHidden)
         }
+    }
+    
+    func testSetOnAppearExport() {
+        let webController = WebViewController()
+        webController.addBridgeAPIObject()
         
+        let result = webController.bridgeContext.evaluateScript("NativeBridge.view.setOnAppear")!
+        XCTAssert(result.isObject)
+        XCTAssert(result.toObject() is NSDictionary)
+    }
+    
+    func testSetOnDisappearExport() {
+        let webController = WebViewController()
+        webController.addBridgeAPIObject()
+        
+        let result = webController.bridgeContext.evaluateScript("NativeBridge.view.setOnDisappear")!
+        XCTAssert(result.isObject)
+        XCTAssert(result.toObject() is NSDictionary)
     }
 }

--- a/ELHybridWebTests/WebViewControllerTests.swift
+++ b/ELHybridWebTests/WebViewControllerTests.swift
@@ -51,6 +51,24 @@ class WebViewControllerTests: XCTestCase {
         XCTAssert(result.toObject() is Navigation)
     }
     
+    func testNavigationAnimateForwardExport() {
+        let webController = WebViewController()
+        webController.addBridgeAPIObject()
+        
+        let result = webController.bridgeContext.evaluateScript("NativeBridge.navigation.animateForward")!
+        XCTAssert(result.isObject)
+        XCTAssert(result.toObject() is NSDictionary)
+    }
+    
+    func testNavigationSetOnBackExport() {
+        let webController = WebViewController()
+        webController.addBridgeAPIObject()
+        
+        let result = webController.bridgeContext.evaluateScript("NativeBridge.navigation.setOnBack")!
+        XCTAssert(result.isObject)
+        XCTAssert(result.toObject() is NSDictionary)
+    }
+    
     func testNavigationBarExport() {
         let webController = WebViewController()
         webController.addBridgeAPIObject()

--- a/ELHybridWebTests/WebViewControllerTests.swift
+++ b/ELHybridWebTests/WebViewControllerTests.swift
@@ -69,6 +69,15 @@ class WebViewControllerTests: XCTestCase {
         XCTAssert(result.toObject() is NSDictionary)
     }
     
+    func testNavigationPresentModalExport() {
+        let webController = WebViewController()
+        webController.addBridgeAPIObject()
+        
+        let result = webController.bridgeContext.evaluateScript("NativeBridge.navigation.presentModal")!
+        XCTAssert(result.isObject)
+        XCTAssert(result.toObject() is NSDictionary)
+    }
+    
     func testNavigationBarExport() {
         let webController = WebViewController()
         webController.addBridgeAPIObject()

--- a/Source/JS API/HybridAPI+Logging.swift
+++ b/Source/JS API/HybridAPI+Logging.swift
@@ -11,11 +11,11 @@ import JavaScriptCore
 import ELLog
 
 @objc protocol HybridLoggingJSExport: JSExport {
-    func log(value: AnyObject)
+    func log(_ value: AnyObject)
 }
 
 extension HybridAPI {
-    func log(value: AnyObject) {
+    func log(_ value: AnyObject) {
         self.log(.Info, "HybridAPI: \(value)")
     }
     

--- a/Source/JS API/HybridAPI+View.swift
+++ b/Source/JS API/HybridAPI+View.swift
@@ -11,8 +11,8 @@ import UIKit
 
 @objc protocol ViewJSExport: JSExport {
     func show()
-    func setOnAppear(callback: JSValue)
-    func setOnDisappear(callback: JSValue)
+    func setOnAppear(_ callback: JSValue)
+    func setOnDisappear(_ callback: JSValue)
 }
 
 @objc public class ViewAPI: ViewControllerChild  {
@@ -40,12 +40,12 @@ extension ViewAPI: ViewJSExport {
         }
     }
     
-    public func setOnAppear(callback: JSValue) {
+    public func setOnAppear(_ callback: JSValue) {
         log(.Debug, "\(self) callback:\(callback)") // provide breadcrumbs
         onAppearCallback = callback
     }
     
-    public func setOnDisappear(callback: JSValue) {
+    public func setOnDisappear(_ callback: JSValue) {
         log(.Debug, "\(self) callback:\(callback)") // provide breadcrumbs
         onDisappearCallback = callback
     }

--- a/Source/JS API/Navigation+External.swift
+++ b/Source/JS API/Navigation+External.swift
@@ -9,13 +9,13 @@
 import JavaScriptCore
 
 @objc protocol ExternalNavigationJSExport: JSExport {
-    func presentExternalURL(options: [String: String])
-    func dismissExternalURL(urlString: String)
+    func presentExternalURL(_ options: [String: String])
+    func dismissExternalURL(_ urlString: String)
 }
 
 extension Navigation: ExternalNavigationJSExport {
     
-    func presentExternalURL(options: [String: String])  {
+    func presentExternalURL(_ options: [String: String])  {
         log(.Debug, "options:\(options)") // provide breadcrumbs
         if let externalOptions = ExternalNavigationOptions(options: options) {
             DispatchQueue.main.async {
@@ -24,7 +24,7 @@ extension Navigation: ExternalNavigationJSExport {
         }
     }
     
-    func dismissExternalURL(urlString: String) {
+    func dismissExternalURL(_ urlString: String) {
         log(.Debug, "urlString\(urlString)") // provide breadcrumbs
         if let url = URL(string: urlString) {
             if let presentingWebViewController = webViewController?.externalPresentingWebViewController {

--- a/Source/JS API/Navigation+Modal.swift
+++ b/Source/JS API/Navigation+Modal.swift
@@ -9,12 +9,12 @@
 import JavaScriptCore
 
 @objc protocol ModalNavigationJSExport: JSExport {
-    func presentModal(options: JSValue)
+    func presentModal(_ options: JSValue)
     func dismissModal()
 }
 
 extension Navigation: ModalNavigationJSExport {
-    func presentModal(options: JSValue) {
+    func presentModal(_ options: JSValue) {
         log(.Debug, "\(self) options:\(options)")
         DispatchQueue.main.async {
             let vcOptions = WebViewControllerOptions(javaScriptValue: options)

--- a/Source/JS API/Navigation.swift
+++ b/Source/JS API/Navigation.swift
@@ -9,7 +9,7 @@
 import JavaScriptCore
 
 @objc protocol NavigationJSExport: JSExport {
-    func animateForward(options: JSValue,  _ callback: JSValue)
+    func animateForward(_ options: JSValue,  _ callback: JSValue)
     func animateBackward()
     func popToRoot()
     func setOnBack(callback: JSValue)
@@ -22,7 +22,7 @@ import JavaScriptCore
     }
     private var onBackCallback: JSValue?
 
-    func animateForward(options: JSValue, _ callback: JSValue) {
+    func animateForward(_ options: JSValue, _ callback: JSValue) {
         log(.Debug, "\(self) options:\(options), callback:\(callback)") // provide breadcrumbs
         DispatchQueue.main.async {
             let vcOptions = WebViewControllerOptions(javaScriptValue: options)

--- a/Source/JS API/Navigation.swift
+++ b/Source/JS API/Navigation.swift
@@ -12,7 +12,7 @@ import JavaScriptCore
     func animateForward(_ options: JSValue,  _ callback: JSValue)
     func animateBackward()
     func popToRoot()
-    func setOnBack(callback: JSValue)
+    func setOnBack(_ callback: JSValue)
 }
 
 @objc public class Navigation: ViewControllerChild, NavigationJSExport {
@@ -55,7 +55,7 @@ import JavaScriptCore
         }
     }
 
-    func setOnBack(callback: JSValue) {
+    func setOnBack(_ callback: JSValue) {
         log(.Debug, "\(self) callback:\(callback)") // provide breadcrumbs
         onBackCallback = callback
     }

--- a/Source/JS API/NavigationBar.swift
+++ b/Source/JS API/NavigationBar.swift
@@ -9,8 +9,8 @@
 import JavaScriptCore
 
 @objc protocol NavigationBarJSExport: JSExport {
-    func setTitle(title: JSValue, _ callback: JSValue?)
-    func setButtons(buttonsToSet: JSValue?, _ callback: JSValue?, _ testingCallback: JSValue?)
+    func setTitle(_ title: JSValue, _ callback: JSValue?)
+    func setButtons(_ buttonsToSet: JSValue?, _ callback: JSValue?, _ testingCallback: JSValue?)
 }
 
 @objc public class NavigationBar: ViewControllerChild {
@@ -46,8 +46,7 @@ import JavaScriptCore
 }
 
 extension NavigationBar: NavigationBarJSExport {
-    
-    func setTitle(title: JSValue, _ callback: JSValue? = nil) {
+    func setTitle(_ title: JSValue, _ callback: JSValue? = nil) {
         log(.Debug, "title:\(title), callback\(callback)") // provide breadcrumbs
         DispatchQueue.main.async {
             self.title = title.asString
@@ -55,7 +54,7 @@ extension NavigationBar: NavigationBarJSExport {
         }
     }
     
-    func setButtons(buttonsToSet: JSValue?, _ callback: JSValue? = nil, _ testingCallback: JSValue? = nil) {
+    func setButtons(_ buttonsToSet: JSValue?, _ callback: JSValue? = nil, _ testingCallback: JSValue? = nil) {
         log(.Debug, "buttonsToSet\(buttonsToSet), callback:\(callback)") // provide breadcrumbs
         DispatchQueue.main.async {
             self.configureButtons(buttonsToSet, callback: callback)


### PR DESCRIPTION
- update all hybrid APIs to export to JS properly after Swift 3 migration mistakenly converted the APIs to be wrongly exported
- add unit tests to verify that the APIs are being exported to JS as expected (per documentation)