### PR TITLE
Add a static framework target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ install:
   - carthage update --no-build
 
 script:
-   - xcodebuild -project ELHybridWeb.xcodeproj -scheme ELHybridWeb -sdk iphonesimulator test -destination 'OS=10.0,name=iPhone 6s Plus' CODE_SIGNING_REQUIRED=NO
+   - xcodebuild -project ELHybridWeb.xcodeproj -scheme ELHybridWeb -sdk iphonesimulator clean test -destination 'OS=10.0,name=iPhone 6s Plus' CODE_SIGNING_REQUIRED=NO
+   - xcodebuild -project ELHybridWeb.xcodeproj -scheme ELHybridWeb_static -sdk iphonesimulator clean build -destination 'OS=10.0,name=iPhone 6s Plus' CODE_SIGNING_REQUIRED=NO

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "Electrode-iOS/ELLog" ~> 5.0.0
+github "Electrode-iOS/ELLog" ~> 5.1.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "Electrode-iOS/ELLog" "v5.0.0"
+github "Electrode-iOS/ELLog" "v5.1.0"

--- a/ELHybridWeb.xcodeproj/project.pbxproj
+++ b/ELHybridWeb.xcodeproj/project.pbxproj
@@ -38,6 +38,29 @@
 		17FA96741B5D4954000B4754 /* HybridAPIInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17FA96731B5D4954000B4754 /* HybridAPIInfo.swift */; };
 		1993579F1B96651000408546 /* WebViewControllerOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1993579E1B96651000408546 /* WebViewControllerOptionsTests.swift */; };
 		19FECF621B9615720095440B /* BarButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19FECF611B9615720095440B /* BarButtonTests.swift */; };
+		3E8CA31320E57B9300CBDA69 /* HybridAPI+Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 177E5D871B00FE1A006BCBE2 /* HybridAPI+Logging.swift */; };
+		3E8CA31420E57B9300CBDA69 /* HybridAPI+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 172B6C4E1B5EAC1700D2E9D2 /* HybridAPI+View.swift */; };
+		3E8CA31520E57B9300CBDA69 /* DialogAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1782B23E1B6B0EF800FC0E4B /* DialogAlert.swift */; };
+		3E8CA31620E57B9300CBDA69 /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 177E5D8F1B00FE1A006BCBE2 /* WebViewController.swift */; };
+		3E8CA31720E57B9300CBDA69 /* Dialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1782B2351B6B0EC800FC0E4B /* Dialog.swift */; };
+		3E8CA31820E57B9300CBDA69 /* DialogOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C479321B4C612200F01703 /* DialogOptions.swift */; };
+		3E8CA31920E57B9300CBDA69 /* BarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17711C0D1B20FDFB0043B71E /* BarButton.swift */; };
+		3E8CA31A20E57B9300CBDA69 /* Navigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 177E5D8C1B00FE1A006BCBE2 /* Navigation.swift */; };
+		3E8CA31B20E57B9300CBDA69 /* HybridAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 177E5D8A1B00FE1A006BCBE2 /* HybridAPI.swift */; };
+		3E8CA31C20E57B9300CBDA69 /* TabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17B435691B667B4D00446D71 /* TabBar.swift */; };
+		3E8CA31D20E57B9300CBDA69 /* WebViewControllerOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1795F5EA1B73A3B60070BB49 /* WebViewControllerOptions.swift */; };
+		3E8CA31E20E57B9300CBDA69 /* NavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 174CA6C41B20804400A80074 /* NavigationBar.swift */; };
+		3E8CA31F20E57B9300CBDA69 /* HybridAPIInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17FA96731B5D4954000B4754 /* HybridAPIInfo.swift */; };
+		3E8CA32020E57B9300CBDA69 /* HybridAPI+Share.swift in Sources */ = {isa = PBXBuildFile; fileRef = 177E5D891B00FE1A006BCBE2 /* HybridAPI+Share.swift */; };
+		3E8CA32120E57B9300CBDA69 /* HybridAPI+Dialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 177E5D861B00FE1A006BCBE2 /* HybridAPI+Dialog.swift */; };
+		3E8CA32220E57B9300CBDA69 /* JSValue+HybridAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 177E5D8B1B00FE1A006BCBE2 /* JSValue+HybridAPI.swift */; };
+		3E8CA32320E57B9300CBDA69 /* Navigation+External.swift in Sources */ = {isa = PBXBuildFile; fileRef = 170DE10C1B8C872300E9C3E9 /* Navigation+External.swift */; };
+		3E8CA32420E57B9300CBDA69 /* Navigation+Modal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BEBC9F1B2F60B100B0FB3E /* Navigation+Modal.swift */; };
+		3E8CA32520E57B9300CBDA69 /* Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = 172F077D1B4C67A100C96ABF /* Util.swift */; };
+		3E8CA32620E57B9300CBDA69 /* ELHybridWeb.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5A6A161C6E80AF00418372 /* ELHybridWeb.swift */; };
+		3E8CA32720E57B9300CBDA69 /* UIWebView+JavaScriptContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E076E21B024AC4008F89EC /* UIWebView+JavaScriptContext.swift */; };
+		3E8CA32820E57B9300CBDA69 /* ViewControllerChild.swift in Sources */ = {isa = PBXBuildFile; fileRef = 177E5D8E1B00FE1A006BCBE2 /* ViewControllerChild.swift */; };
+		3E8CA32C20E57B9300CBDA69 /* ELHybridWeb.h in Headers */ = {isa = PBXBuildFile; fileRef = 173E4E5D1B00FDAD00ACBCCA /* ELHybridWeb.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CA5A6A171C6E80AF00418372 /* ELHybridWeb.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5A6A161C6E80AF00418372 /* ELHybridWeb.swift */; };
 /* End PBXBuildFile section */
 
@@ -76,6 +99,20 @@
 			proxyType = 1;
 			remoteGlobalIDString = CA8D47BA1AAE6FF50028B74D;
 			remoteInfo = ELLog;
+		};
+		3E8CA33720E57B9300CBDA69 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 17A146241DB7251800309044 /* ELLog.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 3EBC4B8E20E55C2D00013E61;
+			remoteInfo = ELLog_static;
+		};
+		3E8CA3C920E57F8C00CBDA69 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 17A146241DB7251800309044 /* ELLog.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 3EBC4B7C20E55C2D00013E61;
+			remoteInfo = ELLog_static;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -127,6 +164,7 @@
 		17FA96731B5D4954000B4754 /* HybridAPIInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HybridAPIInfo.swift; sourceTree = "<group>"; };
 		1993579E1B96651000408546 /* WebViewControllerOptionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebViewControllerOptionsTests.swift; sourceTree = "<group>"; };
 		19FECF611B9615720095440B /* BarButtonTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BarButtonTests.swift; sourceTree = "<group>"; };
+		3E8CA33220E57B9300CBDA69 /* ELHybridWeb.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ELHybridWeb.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CA5A6A161C6E80AF00418372 /* ELHybridWeb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ELHybridWeb.swift; path = Source/ELHybridWeb.swift; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
@@ -140,6 +178,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		173E4E601B00FDAE00ACBCCA /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3E8CA32920E57B9300CBDA69 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -164,6 +209,7 @@
 			children = (
 				173E4E581B00FDAD00ACBCCA /* ELHybridWeb.framework */,
 				173E4E631B00FDAE00ACBCCA /* ELHybridWebTests.xctest */,
+				3E8CA33220E57B9300CBDA69 /* ELHybridWeb.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -259,6 +305,7 @@
 			isa = PBXGroup;
 			children = (
 				17A1462B1DB7251800309044 /* ELLog.framework */,
+				3E8CA33820E57B9300CBDA69 /* ELLog.framework */,
 				17A1462D1DB7251800309044 /* ELLogTests.xctest */,
 				17A1462F1DB7251800309044 /* ELLog.framework */,
 			);
@@ -281,6 +328,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				173E4E5E1B00FDAD00ACBCCA /* ELHybridWeb.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3E8CA32B20E57B9300CBDA69 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3E8CA32C20E57B9300CBDA69 /* ELHybridWeb.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -325,6 +380,25 @@
 			productReference = 173E4E631B00FDAE00ACBCCA /* ELHybridWebTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		3E8CA30F20E57B9300CBDA69 /* ELHybridWeb_static */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3E8CA32E20E57B9300CBDA69 /* Build configuration list for PBXNativeTarget "ELHybridWeb_static" */;
+			buildPhases = (
+				3E8CA31220E57B9300CBDA69 /* Sources */,
+				3E8CA32920E57B9300CBDA69 /* Frameworks */,
+				3E8CA32B20E57B9300CBDA69 /* Headers */,
+				3E8CA32D20E57B9300CBDA69 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				3E8CA3CA20E57F8C00CBDA69 /* PBXTargetDependency */,
+			);
+			name = ELHybridWeb_static;
+			productName = ELHybridWeb;
+			productReference = 3E8CA33220E57B9300CBDA69 /* ELHybridWeb.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -364,6 +438,7 @@
 			projectRoot = "";
 			targets = (
 				173E4E571B00FDAD00ACBCCA /* ELHybridWeb */,
+				3E8CA30F20E57B9300CBDA69 /* ELHybridWeb_static */,
 				173E4E621B00FDAE00ACBCCA /* ELHybridWebTests */,
 			);
 		};
@@ -391,6 +466,13 @@
 			remoteRef = 17A1462E1DB7251800309044 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
+		3E8CA33820E57B9300CBDA69 /* ELLog.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = ELLog.framework;
+			remoteRef = 3E8CA33720E57B9300CBDA69 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 /* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
@@ -402,6 +484,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		173E4E611B00FDAE00ACBCCA /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3E8CA32D20E57B9300CBDA69 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -455,6 +544,35 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		3E8CA31220E57B9300CBDA69 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3E8CA31320E57B9300CBDA69 /* HybridAPI+Logging.swift in Sources */,
+				3E8CA31420E57B9300CBDA69 /* HybridAPI+View.swift in Sources */,
+				3E8CA31520E57B9300CBDA69 /* DialogAlert.swift in Sources */,
+				3E8CA31620E57B9300CBDA69 /* WebViewController.swift in Sources */,
+				3E8CA31720E57B9300CBDA69 /* Dialog.swift in Sources */,
+				3E8CA31820E57B9300CBDA69 /* DialogOptions.swift in Sources */,
+				3E8CA31920E57B9300CBDA69 /* BarButton.swift in Sources */,
+				3E8CA31A20E57B9300CBDA69 /* Navigation.swift in Sources */,
+				3E8CA31B20E57B9300CBDA69 /* HybridAPI.swift in Sources */,
+				3E8CA31C20E57B9300CBDA69 /* TabBar.swift in Sources */,
+				3E8CA31D20E57B9300CBDA69 /* WebViewControllerOptions.swift in Sources */,
+				3E8CA31E20E57B9300CBDA69 /* NavigationBar.swift in Sources */,
+				3E8CA31F20E57B9300CBDA69 /* HybridAPIInfo.swift in Sources */,
+				3E8CA32020E57B9300CBDA69 /* HybridAPI+Share.swift in Sources */,
+				3E8CA32120E57B9300CBDA69 /* HybridAPI+Dialog.swift in Sources */,
+				3E8CA32220E57B9300CBDA69 /* JSValue+HybridAPI.swift in Sources */,
+				3E8CA32320E57B9300CBDA69 /* Navigation+External.swift in Sources */,
+				3E8CA32420E57B9300CBDA69 /* Navigation+Modal.swift in Sources */,
+				3E8CA32520E57B9300CBDA69 /* Util.swift in Sources */,
+				3E8CA32620E57B9300CBDA69 /* ELHybridWeb.swift in Sources */,
+				3E8CA32720E57B9300CBDA69 /* UIWebView+JavaScriptContext.swift in Sources */,
+				3E8CA32820E57B9300CBDA69 /* ViewControllerChild.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -467,6 +585,11 @@
 			isa = PBXTargetDependency;
 			name = ELLog;
 			targetProxy = 17A146301DB7253000309044 /* PBXContainerItemProxy */;
+		};
+		3E8CA3CA20E57F8C00CBDA69 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = ELLog_static;
+			targetProxy = 3E8CA3C920E57F8C00CBDA69 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -742,6 +865,60 @@
 			};
 			name = QADeployment;
 		};
+		3E8CA32F20E57B9300CBDA69 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = ELHybridWeb/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				PRODUCT_BUNDLE_IDENTIFIER = com.walmartlabs.ELHybridWeb;
+				PRODUCT_NAME = ELHybridWeb;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+			};
+			name = Debug;
+		};
+		3E8CA33020E57B9300CBDA69 /* QADeployment */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = ELHybridWeb/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				PRODUCT_BUNDLE_IDENTIFIER = com.walmartlabs.ELHybridWeb;
+				PRODUCT_NAME = ELHybridWeb;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+			};
+			name = QADeployment;
+		};
+		3E8CA33120E57B9300CBDA69 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = ELHybridWeb/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				PRODUCT_BUNDLE_IDENTIFIER = com.walmartlabs.ELHybridWeb;
+				PRODUCT_NAME = ELHybridWeb;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -771,6 +948,16 @@
 				173E4E721B00FDAE00ACBCCA /* Debug */,
 				20DC78741BFEA224004AF8C8 /* QADeployment */,
 				173E4E731B00FDAE00ACBCCA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3E8CA32E20E57B9300CBDA69 /* Build configuration list for PBXNativeTarget "ELHybridWeb_static" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3E8CA32F20E57B9300CBDA69 /* Debug */,
+				3E8CA33020E57B9300CBDA69 /* QADeployment */,
+				3E8CA33120E57B9300CBDA69 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ ELHybridWeb requires Swift 4 and Xcode 9.2.
 Install manually by adding ELHybridWeb.xcodeproj to your project and configuring your target to link ELHybridWeb.framework from `ELHybridWeb` target.
 
 There are two target that builds `ELHybridWeb.framework`.
-1. `ELHybridWeb`: Creates dynamicly linked `ELHybridWeb.framework.`
-2. `ELHybridWeb_static`: Creates staticly linked `ELHybridWeb.framework`.
+1. `ELHybridWeb`: Creates dynamically linked `ELHybridWeb.framework.`
+2. `ELHybridWeb_static`: Creates statically linked `ELHybridWeb.framework`.
 
 ### Carthage
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ ELHybridWeb requires Swift 4 and Xcode 9.2.
 
 ### Manual
 
-Install manually by adding ELHybridWeb.xcodeproj to your project and configuring your target to link ELHybridWeb.framework.
+Install manually by adding ELHybridWeb.xcodeproj to your project and configuring your target to link ELHybridWeb.framework from `ELHybridWeb` target.
+
+There are two target that builds `ELHybridWeb.framework`.
+1. `ELHybridWeb`: Creates dynamicly linked `ELHybridWeb.framework.`
+2. `ELHybridWeb_static`: Creates staticly linked `ELHybridWeb.framework`.
 
 ### Carthage
 


### PR DESCRIPTION
This change adds a new target named `ELHybridWeb_static`. This target builds a static version of `ELHybridWeb.framework.` 
- It shares the same source files as dynamic ELHybridWeb framework and builds a product with the same name. 
- Framework's module name is also the same as that of dynamic framework.
- It uses the same Info.plist file as dynamic framework target.
- Travis script is updated to build both targets and clean before building.

Going forward, `ELHybridWeb_static` framework needs to be managed as well as `ELHybridWeb` target. Sources added or removed, build setting changes, build phase changes should be reflected on `ELHybridWeb_static` target.

Cartfile will be updated when https://github.com/Electrode-iOS/ELLog/pull/38 is merged and new versions of ELLog is available.
